### PR TITLE
Add keywords for crates.io

### DIFF
--- a/fourier/Cargo.toml
+++ b/fourier/Cargo.toml
@@ -17,6 +17,7 @@ include = [
     "/tests/**/*.rs",
     "/tests/**/*.json",
 ]
+keywords = ["fft", "fourier", "transform"]
 
 [dependencies]
 num-traits = "0.2"


### PR DESCRIPTION
Currently this crate does not appear on crates.io when searching for fft.